### PR TITLE
Fix url parameter for yum_repository resource

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -37,7 +37,7 @@ when "centos", "redhat"
 
   yum_repository "sensu" do
     repo = node.sensu.use_unstable_repo ? "yum-unstable" : "yum"
-    url "http://repos.sensuapp.org/#{repo}/el/#{node['platform_version'].to_i}/$basearch/"
+    baseurl "http://repos.sensuapp.org/#{repo}/el/#{node['platform_version'].to_i}/$basearch/"
     action :add
   end
 when "fedora"


### PR DESCRIPTION
## Description

Use of the `url` parameter for `yum_repository` resources is currently broken. It's also deprecated in favor of using `baseurl`.
## Motivation and Context

Issue: https://github.com/chef/chef/issues/5317
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
